### PR TITLE
feat: support serialization to JSON and binary for Stack.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 # I think we need to mention this for secp256k1-sys to work
 getrandom = { version = "0.2", optional = true }
 
+[dev-dependencies]
+bincode = { version = "1.3" }
+
 [patch.crates-io.base58check]
 git = "https://github.com/rust-bitcoin/rust-bitcoin"
 branch = "bitvm"


### PR DESCRIPTION
Changelogs:
- Support serialization and deserialization for Stack.
- Test the function correctness for JSON and Binary Serialization.
- Mark `serialize_to_bytes` in Stack and StackEntry to be deprecated.
- Format the file.

The compatibility is kept between commits.