### PR TITLE
Bug Report: Issues with `popstr`, `topstr`, `as_bytes`, `iter_str`, and `get`

### DIFF
--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -172,7 +172,14 @@ impl Stack {
     pub fn popstr(&mut self) -> Result<Vec<u8>, ExecError> {
         let entry = self.0.pop().ok_or(ExecError::InvalidStackOperation)?;
         match entry {
-            StackEntry::Num(v) => Ok(script::scriptint_vec(v)),
+            StackEntry::Num(v) => {
+                let res = script::scriptint_vec(v);
+                if res.is_empty() {
+                    Ok(vec![0])
+                } else {
+                    Ok(res)
+                }
+            },
             StackEntry::StrRef(v) => Ok(v.borrow().to_vec()),
         }
     }

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -25,7 +25,14 @@ impl StackEntry {
     // This assumes the StackEntry fit in a u32 and will pad it with leading zeros to 4 bytes.
     pub fn as_bytes(&self) -> Vec<u8> {
         match self {
-            StackEntry::Num(v) => script::scriptint_vec(*v),
+            StackEntry::Num(v) => {
+                let res = script::scriptint_vec(*v);
+                if res.is_empty() {
+                    vec![0]
+                } else {
+                    res
+                }
+            },
             StackEntry::StrRef(v) => {
                 let v = v.borrow().to_vec();
                 assert!(
@@ -118,7 +125,14 @@ impl Stack {
     pub fn topstr(&self, offset: isize) -> Result<Vec<u8>, ExecError> {
         let entry = self.top(offset)?;
         match entry {
-            StackEntry::Num(v) => Ok(script::scriptint_vec(*v)),
+            StackEntry::Num(v) => {
+                let res = script::scriptint_vec(*v);
+                if res.is_empty() {
+                    Ok(vec![0])
+                } else {
+                    Ok(res)
+                }
+            },
             StackEntry::StrRef(v) => Ok(v.borrow().to_vec()),
         }
     }
@@ -179,7 +193,7 @@ impl Stack {
                 } else {
                     Ok(res)
                 }
-            },
+            }
             StackEntry::StrRef(v) => Ok(v.borrow().to_vec()),
         }
     }
@@ -208,14 +222,28 @@ impl Stack {
 
     pub fn iter_str(&self) -> Map<Iter<StackEntry>, fn(&StackEntry) -> Vec<u8>> {
         self.0.iter().map(|v| match v {
-            StackEntry::Num(v) => script::scriptint_vec(*v),
+            StackEntry::Num(v) => {
+                let res = script::scriptint_vec(*v);
+                if res.is_empty() {
+                    vec![0]
+                } else {
+                    res
+                }
+            },
             StackEntry::StrRef(v) => v.borrow().to_vec(),
         })
     }
 
     pub fn get(&self, index: usize) -> Vec<u8> {
         match &self.0[index] {
-            StackEntry::Num(v) => script::scriptint_vec(*v),
+            StackEntry::Num(v) => {
+                let res= script::scriptint_vec(*v);
+                if res.is_empty() {
+                    vec![0]
+                } else {
+                    res
+                }
+            },
             StackEntry::StrRef(v) => v.borrow().to_vec(),
         }
     }


### PR DESCRIPTION
We've identified multiple critical issues within functions in `data_structures.rs`, specifically impacting `popstr`, `topstr`, `as_bytes`, `iter_str`, and `get`. These functions incorrectly handle `Num(0)`, leading to an unintended `nil` (empty vector) return instead of the expected `vec![0]`. This behavior could cause severe execution errors, particularly during `pop` operations on `Num(0)`.

### Key Problem in Each Function:

1. **`popstr`**: As previously detailed, when `Num(0)` is encountered, it returns an empty vector instead of `[0]`, due to the behavior of `scriptint_vec` and `write_scriptint`.

    ```rust
    pub fn popstr(&mut self) -> Result<Vec<u8>, ExecError> {
        let entry = self.0.pop().ok_or(ExecError::InvalidStackOperation)?;
        match entry {
            StackEntry::Num(v) => Ok(script::scriptint_vec(v)),  // Returns nil on `Num(0)`
            StackEntry::StrRef(v) => Ok(v.borrow().to_vec()),
        }
    }
    ```

2. **`topstr`**: This function likely has the same issue, returning `nil` instead of `[0]` when accessing the top stack entry of `Num(0)`.

3. **`as_bytes`**: Similarly, `as_bytes` could fail to handle `Num(0)` correctly, returning an empty vector where `[0]` is expected.

4. **`iter_str`**: This iterator could propagate the `nil` issue throughout the stack when iterating over elements that should contain `Num(0)` as `[0]`.

5. **`get`**: When `get` is used to access an element that is `Num(0)`, it may incorrectly provide an empty vector result, which could lead to further propagation of errors.

### Core Issue
The root cause in each case is the incorrect handling of `Num(0)` in `scriptint_vec` and `write_scriptint`, which returns zero length for zero values rather than encoding `[0]`. This affects all functions relying on `scriptint_vec` to process `Num` values, leading to unintended `nil` outputs during script execution.