### PR TITLE
Support concatenation of asm script files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,15 @@ $ cargo install --locked --path .
 
 ### Usage
 
-The CLI currently takes only a single argument: the path to the ASM script file:
+The CLI takes one or more arguments: the path(s) to the ASM script file(s):
 
 ```
 # using the binary
 $ btcexec <script.bs>
 # using cargo run
 $ cargo run -- <script.bs>
+# concatenating multiple scripts
+$ btcexec <unlockingscript.bs> <lockingscript.bs>
 ```
 
 ## WASM

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use bitcoin_scriptexec::*;
 struct Args {
     /// filepath to script ASM file
     #[arg(required = true)]
-    script_path: PathBuf,
+    script_path: Vec<PathBuf>,
     /// Whether to print debug info
     #[arg(long)]
     debug: bool,
@@ -42,8 +42,12 @@ impl fmt::Display for FmtStack<'_> {
 fn inner_main() -> Result<(), String> {
     let args = Args::parse();
 
-    let script_asm = std::fs::read_to_string(args.script_path).expect("error reading script file");
-    let script = ScriptBuf::from_asm(&script_asm).expect("error parsing script");
+    let mut script = String::new();
+    for script_path in args.script_path {
+        let script_asm = std::fs::read_to_string(script_path).expect("error reading script file");
+        script.push_str(&script_asm);
+    }
+    let script = ScriptBuf::from_asm(&script).expect("error parsing script");
     println!("Script in hex: {}", script.as_bytes().to_lower_hex_string());
     println!("Script size: {} bytes", script.as_bytes().len());
 


### PR DESCRIPTION
### Description
Supports execution of multiple scripts chained together

### Overview
Thanks for creating this project, I have found it quite nice to use recently in an educational context.

Made a very small addition that I have found useful, which just reads in multiple files concatenated together. This was nice for the question of "does script X unlock script Y". Figured I'd PR it in case it's useful for others!

### Testing
Try writing up two scripts and execute them together 
Ex. 
```
# makes-eight.bs
OP_1
OP_DUP
OP_ADD
OP_DUP
OP_ADD
OP_DUP
OP_ADD
```
```
# checks-equal-to-eight.bs
OP_8
OP_EQUAL
```
Executing:
```
$ btcexec ./makes-eight.bs ./checks-equal-to-eight.bs
Script in hex: 517693769376935887
Script size: 9 bytes
--------------------------------------------------
Execution ended. Success: true
Final stack: <01>
Stats:
ExecStats {
    max_nb_stack_items: 2,
    opcode_count: 0,
    start_validation_weight: 51,
    validation_weight: 51,
}
Time elapsed: 0ms
```
Executing with `--debug` 
```
)$ btcexec ./makes-eight.bs ./checks-equal-to-eight.bs --debug
Script in hex: 517693769376935887
Script size: 9 bytes
--------------------------------------------------
Remaining script: OP_PUSHNUM_1 OP_DUP OP_ADD OP_DUP OP_ADD OP_DUP OP_ADD OP_PUSHNUM_8 OP_EQUAL
Stack: 
AltStack: 
--------------------------------------------------
Remaining script: OP_DUP OP_ADD OP_DUP OP_ADD OP_DUP OP_ADD OP_PUSHNUM_8 OP_EQUAL
Stack: <01>
AltStack: 
--------------------------------------------------
Remaining script: OP_ADD OP_DUP OP_ADD OP_DUP OP_ADD OP_PUSHNUM_8 OP_EQUAL
Stack: <01> <01>
AltStack: 
--------------------------------------------------
Remaining script: OP_DUP OP_ADD OP_DUP OP_ADD OP_PUSHNUM_8 OP_EQUAL
Stack: <02>
AltStack: 
--------------------------------------------------
Remaining script: OP_ADD OP_DUP OP_ADD OP_PUSHNUM_8 OP_EQUAL
Stack: <02> <02>
AltStack: 
--------------------------------------------------
Remaining script: OP_DUP OP_ADD OP_PUSHNUM_8 OP_EQUAL
Stack: <04>
AltStack: 
--------------------------------------------------
Remaining script: OP_ADD OP_PUSHNUM_8 OP_EQUAL
Stack: <04> <04>
AltStack: 
--------------------------------------------------
Remaining script: OP_PUSHNUM_8 OP_EQUAL
Stack: <08>
AltStack: 
--------------------------------------------------
Remaining script: OP_EQUAL
Stack: <08> <08>
AltStack: 
--------------------------------------------------
Remaining script: 
Stack: <01>
AltStack: 
--------------------------------------------------
Execution ended. Success: true
Final stack: <01>
Stats:
ExecStats {
    max_nb_stack_items: 2,
    opcode_count: 0,
    start_validation_weight: 51,
    validation_weight: 51,
}
Time elapsed: 0ms
```