### PR TITLE
Add a getter for the Exec's cond_stack

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,6 +331,10 @@ impl Exec {
         &self.stats
     }
 
+    pub fn cond_stack(&self) -> &ConditionStack {
+        &self.cond_stack
+    }
+
     ///////////////
     // UTILITIES //
     ///////////////


### PR DESCRIPTION
Used in a project I'm working on to be able to tell which opcodes are inside unexecuted branches.